### PR TITLE
Dynamic Resize of Dyno Scope + bump version number

### DIFF
--- a/include/oscilloscope_cluster.h
+++ b/include/oscilloscope_cluster.h
@@ -33,6 +33,7 @@ class OscilloscopeCluster : public UiElement {
         Oscilloscope *getSparkAdvanceScope() const { return m_sparkAdvanceScope; }
         Oscilloscope *getCylinderMoleculesScope() const { return m_cylinderMoleculesScope; }
         Oscilloscope *getPvScope() const { return m_pvScope; }
+        void setDynoMaxRange(double redline) { m_torqueScope->m_xMax = redline + 500; m_hpScope->m_xMax = redline + 500; }
 
     protected:
         void renderScope(

--- a/src/engine_sim_application.cpp
+++ b/src/engine_sim_application.cpp
@@ -230,6 +230,7 @@ void EngineSimApplication::initialize() {
 
     m_oscCluster = m_uiManager.getRoot()->addElement<OscilloscopeCluster>();
     m_oscCluster->m_simulator = &m_simulator;
+    m_oscCluster->setDynoMaxRange(units::toRpm(m_iceEngine->getRedline()));
 
     m_performanceCluster = m_uiManager.getRoot()->addElement<PerformanceCluster>();
     m_performanceCluster->setSimulator(&m_simulator);

--- a/src/engine_sim_application.cpp
+++ b/src/engine_sim_application.cpp
@@ -72,7 +72,7 @@ EngineSimApplication::EngineSimApplication() {
     m_viewParameters.Layer0 = 0;
     m_viewParameters.Layer1 = 10;
 
-    buildVersion = "0.1.3a";
+    buildVersion = "0.1.4a";
 }
 
 EngineSimApplication::~EngineSimApplication() {


### PR DESCRIPTION
This PR adds dynamic resizing of the dyno graph to use the redline of the engine and prevent overflow. 
Also Bumps version number to 0.1.4a