### PR TITLE
Fixes to utilities.cpp and audio_buffer.cpp/h

### DIFF
--- a/include/audio_buffer.h
+++ b/include/audio_buffer.h
@@ -67,7 +67,7 @@ class AudioBuffer {
             }
         }
 
-        bool checkForDiscontinuitiy(int threshold) const;
+        bool checkForDiscontinuity(int threshold) const;
 
         int m_writePointer;
 

--- a/src/audio_buffer.cpp
+++ b/src/audio_buffer.cpp
@@ -30,7 +30,7 @@ void AudioBuffer::destroy() {
     m_bufferSize = 0;
 }
 
-bool AudioBuffer::checkForDiscontinuitiy(int threshold) const {
+bool AudioBuffer::checkForDiscontinuity(int threshold) const {
     for (int i = 0; i < m_bufferSize - 1; ++i) {
         const int i0 = getBufferIndex(i + m_writePointer);
         const int i1 = getBufferIndex(i0 + 1);

--- a/src/audio_buffer.cpp
+++ b/src/audio_buffer.cpp
@@ -31,7 +31,9 @@ void AudioBuffer::destroy() {
 }
 
 bool AudioBuffer::checkForDiscontinuity(int threshold) const {
-    for (int i = 0; i < m_bufferSize - 1; ++i) {
+    int i = 0;
+    int m_bufferSizeMinusOne = m_bufferSize - 1;
+    for (; i < m_bufferSizeMinusOne; ++i) {
         const int i0 = getBufferIndex(i + m_writePointer);
         const int i1 = getBufferIndex(i0 + 1);
 

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -2,18 +2,8 @@
 
 #include <cmath>
 
-double modularDistance(double a0, double b0, double mod) {
-    double a, b;
-    if (a0 < b0) {
-        a = a0;
-        b = b0;
-    }
-    else {
-        a = b0;
-        b = a0;
-    }
-
-    return std::fmin(b - a, a + mod - b);
+double modularDistance(double a, double b, double mod) {
+    return (a < b) ? std::fmin(b - a, a + mod - b) : std::fmin(a - b, b + mod - a);
 }
 
 double positiveMod(double x, double mod) {


### PR DESCRIPTION
utilities.cpp: 

- Shortened modularDistance function

audio_buffer:

- Corrected typo (checkForDiscontinuitiy -> checkForDiscontinuity)
- Calculate m_bufferSizeMinusOne outside of for loop to reduce number of computations