### PR TITLE
Fix compilation issues.

### DIFF
--- a/include/camshaft.h
+++ b/include/camshaft.h
@@ -17,7 +17,7 @@ class Camshaft : public Part {
             double Advance = 0;
 
             // Corresponding crankshaft
-            Crankshaft *Crankshaft;
+            Crankshaft *crankshaft;
 
             // Lobe profile
             Function *LobeProfile;

--- a/include/combustion_chamber.h
+++ b/include/combustion_chamber.h
@@ -13,9 +13,9 @@ class Engine;
 class CombustionChamber : public atg_scs::ForceGenerator {
     public:
         struct Parameters {
-            Piston *Piston;
+            Piston *piston;
             CylinderHead *Head;
-            Fuel *Fuel;
+            Fuel *fuel;
             Function *MeanPistonSpeedToTurbulence;
 
             double StartingPressure;

--- a/include/connecting_rod.h
+++ b/include/connecting_rod.h
@@ -17,9 +17,9 @@ class ConnectingRod : public Part {
             int RodJournals = 0;
             double SlaveThrow = 0;
 
-            Piston *Piston = nullptr;
+            Piston *piston = nullptr;
 
-            Crankshaft *Crankshaft = nullptr;
+            Crankshaft *crankshaft = nullptr;
             ConnectingRod *Master = nullptr;
             int Journal = 0;
         };

--- a/include/cylinder_bank.h
+++ b/include/cylinder_bank.h
@@ -8,7 +8,7 @@
 class CylinderBank {
     public:
         struct Parameters {
-            Crankshaft *Crankshaft;
+            Crankshaft *crankshaft;
             double PositionX;
             double PositionY;
             double Angle;

--- a/include/cylinder_head.h
+++ b/include/cylinder_head.h
@@ -18,7 +18,7 @@ class CylinderHead : public Part {
             Function *ExhaustPortFlow;
             Function *IntakePortFlow;
 
-            Valvetrain *Valvetrain;
+            Valvetrain *valvetrain;
 
             double CombustionChamberVolume;
 

--- a/include/exhaust_system.h
+++ b/include/exhaust_system.h
@@ -18,7 +18,7 @@ class ExhaustSystem : public Part {
             double PrimaryFlowRate;
             double VelocityDecay;
             double AudioVolume;
-            ImpulseResponse *ImpulseResponse;
+            ImpulseResponse *impulseResponse;
         };
 
     public:

--- a/include/gas_system.h
+++ b/include/gas_system.h
@@ -37,8 +37,8 @@ class GasSystem {
         ~GasSystem() { /* void */ }
 
         void setGeometry(double width, double height, double dx, double dy);
-        void initialize(double P, double V, double T, const Mix &mix = {}, int degreesOfFreedom = 5);
-        void reset(double P, double T, const Mix &mix = {});
+        void initialize(double P, double V, double T, const Mix &mix = {0.0, 1.0, 0.0}, int degreesOfFreedom = 5);
+        void reset(double P, double T, const Mix &mix = {0.0, 1.0, 0.0});
 
         void setVolume(double V);
         void setN(double n);
@@ -65,14 +65,14 @@ class GasSystem {
             double chokedFlowLimit,
             double chokedFlowRateCached);
         double loseN(double dn, double E_k_per_mol);
-        double gainN(double dn, double E_k_per_mol, const Mix &mix = {});
+        double gainN(double dn, double E_k_per_mol, const Mix &mix = {0.0, 1.0, 0.0});
         void dissipateExcessVelocity();
 
         void updateVelocity(double dt, double beta = 1.0);
         void dissipateVelocity(double dt, double timeConstant);
 
         static double flow(const FlowParameters &params);
-        double flow(double k_flow, double dt, double P_env, double T_env, const Mix &mix = {});
+        double flow(double k_flow, double dt, double P_env, double T_env, const Mix &mix = {0.0, 1.0, 0.0});
 
         double pressureEquilibriumMaxFlow(const GasSystem *b) const;
         double pressureEquilibriumMaxFlow(double P_env, double T_env) const;

--- a/include/ignition_module.h
+++ b/include/ignition_module.h
@@ -11,7 +11,7 @@ class IgnitionModule : public Part {
     public:
         struct Parameters {
             int CylinderCount;
-            Crankshaft *Crankshaft;
+            Crankshaft *crankshaft;
             Function *TimingCurve;
             double RevLimit = units::rpm(6000.0);
             double LimiterDuration = 0.5 * units::sec;

--- a/include/jitter_filter.h
+++ b/include/jitter_filter.h
@@ -18,7 +18,7 @@ public:
         float audioFrequency);
     virtual float f(float sample) override;
 
-    __forceinline float fast_f(float sample, float jitterScale = 1.0f) {
+     float fast_f(float sample, float jitterScale = 1.0f) {
         m_history[m_offset] = sample;
         ++m_offset;
 

--- a/include/low_pass_filter.h
+++ b/include/low_pass_filter.h
@@ -12,7 +12,7 @@ class LowPassFilter : public Filter {
 
         virtual float f(float sample) override;
 
-        __forceinline float fast_f(float sample) {
+         float fast_f(float sample) {
             const float alpha = m_dt / (m_rc + m_dt);
             m_y = alpha * sample + (1 - alpha) * m_y;
 

--- a/include/preemphasis_filter.h
+++ b/include/preemphasis_filter.h
@@ -14,7 +14,7 @@ public:
 
     virtual float f(float sample) override { return fast_f(sample); }
 
-    __forceinline float fast_f(float sample) {
+     inline float fast_f(float sample) {
         const float s = -0.95f * sample + m_lastSample;
 
         m_lastSample = sample;

--- a/src/audio_buffer.cpp
+++ b/src/audio_buffer.cpp
@@ -1,6 +1,7 @@
 #include "../include/audio_buffer.h"
 
 #include <assert.h>
+#include <cmath>
 
 AudioBuffer::AudioBuffer() {
     m_writePointer = 0;

--- a/src/camshaft.cpp
+++ b/src/camshaft.cpp
@@ -25,7 +25,7 @@ void Camshaft::initialize(const Parameters &params) {
     memset(m_lobeAngles, 0, sizeof(double) * params.Lobes);
 
     m_lobes = params.Lobes;
-    m_crankshaft = params.Crankshaft;
+    m_crankshaft = params.crankshaft;
     m_lobeProfile = params.LobeProfile;
     m_advance = params.Advance;
     m_baseRadius = params.BaseRadius;

--- a/src/combustion_chamber.cpp
+++ b/src/combustion_chamber.cpp
@@ -45,9 +45,9 @@ CombustionChamber::~CombustionChamber() {
 }
 
 void CombustionChamber::initialize(const Parameters &params) {
-    m_piston = params.Piston;
+    m_piston = params.piston;
     m_head = params.Head;
-    m_fuel = params.Fuel;
+    m_fuel = params.fuel;
     m_crankcasePressure = params.CrankcasePressure;
     m_meanPistonSpeedToTurbulence = params.MeanPistonSpeedToTurbulence;
 
@@ -74,7 +74,7 @@ void CombustionChamber::initialize(const Parameters &params) {
         height,
         1.0,
         0.0);
-   
+
     const double intakeRunnerCrossSection = m_head->getIntakeRunnerCrossSectionArea();
     const double intakeRunnerWidth = std::sqrt(intakeRunnerCrossSection);
     const double manifoldRunnerLength = intake->getRunnerLength();

--- a/src/connecting_rod.cpp
+++ b/src/connecting_rod.cpp
@@ -1,4 +1,3 @@
-#include "..\include\connecting_rod.h"
 #include "../include/connecting_rod.h"
 
 #include <cmath>
@@ -28,8 +27,8 @@ void ConnectingRod::initialize(const Parameters &params) {
     m_m = params.Mass;
     m_I = params.MomentOfInertia;
     m_journal = params.Journal;
-    m_crankshaft = params.Crankshaft;
-    m_piston = params.Piston;
+    m_crankshaft = params.crankshaft;
+    m_piston = params.piston;
 
     m_rodJournalAngles = new double[params.RodJournals];
     m_rodJournalCount = params.RodJournals;

--- a/src/cylinder_head.cpp
+++ b/src/cylinder_head.cpp
@@ -35,7 +35,7 @@ void CylinderHead::initialize(const Parameters &params) {
     m_soundAttenuation = new double[params.Bank->getCylinderCount()];
 
     m_bank = params.Bank;
-    m_valvetrain = params.Valvetrain;
+    m_valvetrain = params.valvetrain;
     m_exhaustPortFlow = params.ExhaustPortFlow;
     m_intakePortFlow = params.IntakePortFlow;
     m_combustionChamberVolume = params.CombustionChamberVolume;

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -1,5 +1,3 @@
-#include "..\include\engine.h"
-#include "..\include\engine.h"
 #include "../include/engine.h"
 
 #include "../include/constants.h"
@@ -213,7 +211,7 @@ bool placeRod(
 
     *s = std::max(s0, s1);
     if (*s < 0) return false;
-   
+
     if (s != nullptr) {
         const double dx = (bank.getX() + bank.getDx() * (*s)) - (*p_x);
         const double dy = (bank.getY() + bank.getDy() * (*s)) - (*p_y);

--- a/src/exhaust_system.cpp
+++ b/src/exhaust_system.cpp
@@ -47,7 +47,7 @@ void ExhaustSystem::initialize(const Parameters &params) {
     m_collectorCrossSectionArea = params.CollectorCrossSectionArea;
     m_primaryTubeLength = params.PrimaryTubeLength;
     m_velocityDecay = params.VelocityDecay;
-    m_impulseResponse = params.ImpulseResponse;
+    m_impulseResponse = params.impulseResponse;
 }
 
 void ExhaustSystem::destroy() {

--- a/src/ignition_module.cpp
+++ b/src/ignition_module.cpp
@@ -32,7 +32,7 @@ void IgnitionModule::destroy() {
 void IgnitionModule::initialize(const Parameters &params) {
     m_cylinderCount = params.CylinderCount;
     m_plugs = new SparkPlug[m_cylinderCount];
-    m_crankshaft = params.Crankshaft;
+    m_crankshaft = params.crankshaft;
     m_timingCurve = params.TimingCurve;
     m_revLimit = params.RevLimit;
     m_limiterDuration = params.LimiterDuration;

--- a/src/jitter_filter.cpp
+++ b/src/jitter_filter.cpp
@@ -1,4 +1,5 @@
 #include "../include/jitter_filter.h"
+#include <cstring>
 
 JitterFilter::JitterFilter() {
     m_history = nullptr;


### PR DESCRIPTION
I ran into a bunch of issues trying to compile this with Ninja on
Linux (yes I know you have some incompatible dependencies, but
ignoring those for now). Most of the issues come from compiler 
incompatibility rather than platform incompatibility anyhow.

The members named the same as struct defs, and __forceinline were the
main issues. Aside from that, it was the default initializer magick on
Mix (I don't kno if there's a standard way to do what you want here).

`__forceinline` is all over the place in the submodules, so probably
it'd be better to override it with a macro def in the build system.

`__forceinline` is essentially pointless where it is being used, because
these functions are small enough that they will almost always be inlined
to begin with, and AFAIK MSVC can still ignore __forceinline.

There were also a couple of incompatible paths in #includes that
needed fixing.

Feel free to abandon this, merge parts of it, or whatever. I may look at those Windows-specific deps a little closer on the weekend. ;+ )