### PR TITLE
Add cmake options for building engine simulator as a library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required(VERSION 3.10)
 option(DTV "Enable video output" OFF)
 option(PIRANHA_ENABLED "Enable scripting input" ON)
 option(DISCORD_ENABLED "Enable Discord Rich Presence" ON)
+option(BUILD_APP "Build Application" ON)
+option(BUILD_APP_AS_LIB "Build Application as a library" OFF)
 
 if (DTV)
     add_compile_definitions(ATG_ENGINE_SIM_VIDEO_CAPTURE)
@@ -139,6 +141,8 @@ target_link_libraries(engine-sim
 
 target_include_directories(engine-sim
     PUBLIC dependencies/submodules)
+	
+add_subdirectory(dependencies/submodules/simple-2d-constraint-solver)
 
 if (PIRANHA_ENABLED)
     add_library(engine-sim-script-interpreter STATIC
@@ -187,6 +191,8 @@ if (PIRANHA_ENABLED)
     target_link_libraries(engine-sim-script-interpreter
         csv-io
         piranha)
+		
+	add_subdirectory(dependencies/submodules/piranha)
 endif (PIRANHA_ENABLED)
 
 if (DISCORD_ENABLED)
@@ -201,103 +207,117 @@ if (DISCORD_ENABLED)
     )
 endif (DISCORD_ENABLED)
 
-add_executable(engine-sim-app WIN32
-    # Source files
-    src/main.cpp
-    src/engine_sim_application.cpp
-    src/geometry_generator.cpp
-    src/simulation_object.cpp
-    src/piston_object.cpp
-    src/connecting_rod_object.cpp
-    src/ui_element.cpp
-    src/ui_manager.cpp
-    src/cylinder_pressure_gauge.cpp
-    src/ui_math.cpp
-    src/gauge.cpp
-    src/crankshaft_object.cpp
-    src/cylinder_bank_object.cpp
-    src/cylinder_head_object.cpp
-    src/ui_button.cpp
-    src/ui_utilities.cpp
-    src/combustion_chamber_object.cpp
-    src/oscilloscope.cpp
-    src/shaders.cpp
-    src/engine_view.cpp
-    src/right_gauge_cluster.cpp
-    src/cylinder_temperature_gauge.cpp
-    src/labeled_gauge.cpp
-    src/throttle_display.cpp
-    src/afr_cluster.cpp
-    src/fuel_cluster.cpp
-    src/oscilloscope_cluster.cpp
-    src/performance_cluster.cpp
-    src/firing_order_display.cpp
-    src/load_simulation_cluster.cpp
-    src/mixer_cluster.cpp
-    src/info_cluster.cpp
+if (BUILD_APP_AS_LIB OR BUILD_APP)
+	add_library(engine-sim-app-lib STATIC
+		# Source files
+		src/engine_sim_application.cpp
+		src/geometry_generator.cpp
+		src/simulation_object.cpp
+		src/piston_object.cpp
+		src/connecting_rod_object.cpp
+		src/ui_element.cpp
+		src/ui_manager.cpp
+		src/cylinder_pressure_gauge.cpp
+		src/ui_math.cpp
+		src/gauge.cpp
+		src/crankshaft_object.cpp
+		src/cylinder_bank_object.cpp
+		src/cylinder_head_object.cpp
+		src/ui_button.cpp
+		src/ui_utilities.cpp
+		src/combustion_chamber_object.cpp
+		src/oscilloscope.cpp
+		src/shaders.cpp
+		src/engine_view.cpp
+		src/right_gauge_cluster.cpp
+		src/cylinder_temperature_gauge.cpp
+		src/labeled_gauge.cpp
+		src/throttle_display.cpp
+		src/afr_cluster.cpp
+		src/fuel_cluster.cpp
+		src/oscilloscope_cluster.cpp
+		src/performance_cluster.cpp
+		src/firing_order_display.cpp
+		src/load_simulation_cluster.cpp
+		src/mixer_cluster.cpp
+		src/info_cluster.cpp
 
-    # Include files
-    include/delta.h
-    include/dtv.h
-    include/engine_sim_application.h
-    include/geometry_generator.h
-    include/simulation_object.h
-    include/piston_object.h
-    include/connecting_rod_object.h
-    include/ui_element.h
-    include/ui_manager.h
-    include/cylinder_pressure_gauge.h
-    include/ui_math.h
-    include/units.h
-    include/crankshaft_object.h
-    include/cylinder_bank_object.h
-    include/cylinder_head_object.h
-    include/ui_button.h
-    include/ui_utilities.h
-    include/combustion_chamber_object.h
-    include/oscilloscope.h
-    include/shaders.h
-    include/engine_view.h
-    include/right_gauge_cluster.h
-    include/cylinder_temperature_gauge.h
-    include/labeled_gauge.h
-    include/throttle_display.h
-    include/afr_cluster.h
-    include/fuel_cluster.h
-    include/oscilloscope_cluster.h
-    include/performance_cluster.h
-    include/firing_order_display.h
-    include/load_simulation_cluster.h
-    include/mixer_cluster.h
-    include/info_cluster.h
-)
+		# Include files
+		include/delta.h
+		include/dtv.h
+		include/engine_sim_application.h
+		include/geometry_generator.h
+		include/simulation_object.h
+		include/piston_object.h
+		include/connecting_rod_object.h
+		include/ui_element.h
+		include/ui_manager.h
+		include/cylinder_pressure_gauge.h
+		include/ui_math.h
+		include/units.h
+		include/crankshaft_object.h
+		include/cylinder_bank_object.h
+		include/cylinder_head_object.h
+		include/ui_button.h
+		include/ui_utilities.h
+		include/combustion_chamber_object.h
+		include/oscilloscope.h
+		include/shaders.h
+		include/engine_view.h
+		include/right_gauge_cluster.h
+		include/cylinder_temperature_gauge.h
+		include/labeled_gauge.h
+		include/throttle_display.h
+		include/afr_cluster.h
+		include/fuel_cluster.h
+		include/oscilloscope_cluster.h
+		include/performance_cluster.h
+		include/firing_order_display.h
+		include/load_simulation_cluster.h
+		include/mixer_cluster.h
+		include/info_cluster.h
+	)
 
-target_link_libraries(engine-sim-app
-    engine-sim
-)
+	target_link_libraries(engine-sim-app-lib
+		engine-sim
+	)
 
-if (DTV)
-    target_link_libraries(engine-sim-app
-        direct-to-video)
-endif (DTV)
+	if (DTV)
+		target_link_libraries(engine-sim-app-lib
+			direct-to-video)
+		add_subdirectory(dependencies/submodules/direct-to-video)
+	endif (DTV)
 
-if (PIRANHA_ENABLED)
-    target_link_libraries(engine-sim-app
-        engine-sim-script-interpreter)
-endif (PIRANHA_ENABLED)
+	if (PIRANHA_ENABLED)
+		target_link_libraries(engine-sim-app-lib
+			engine-sim-script-interpreter)
+	endif (PIRANHA_ENABLED)
 
-if (DISCORD_ENABLED)
-    add_library(discord-rpc STATIC IMPORTED)
-    set_property(TARGET discord-rpc PROPERTY IMPORTED_LOCATION ${PROJECT_SOURCE_DIR}/dependencies/discord/lib/discord-rpc.lib)
-    target_link_libraries(engine-sim-app
-    	discord
-	discord-rpc)
-endif (DISCORD_ENABLED)
+	if (DISCORD_ENABLED)
+		add_library(discord-rpc STATIC IMPORTED)
+		set_property(TARGET discord-rpc PROPERTY IMPORTED_LOCATION ${PROJECT_SOURCE_DIR}/dependencies/discord/lib/discord-rpc.lib)
+		target_link_libraries(engine-sim-app-lib
+			discord
+		discord-rpc)
+	endif (DISCORD_ENABLED)
 
-target_include_directories(engine-sim-app
-    PUBLIC dependencies/submodules)
+	target_include_directories(engine-sim-app-lib
+		PUBLIC dependencies/submodules)
+		
+	add_subdirectory(dependencies/submodules/delta-studio)
+	add_subdirectory(dependencies/submodules/csv-io)
+endif (BUILD_APP_AS_LIB OR BUILD_APP)
 
-add_subdirectory(dependencies)
+if (BUILD_APP)
+	add_executable(engine-sim-app WIN32
+		# Source files
+		src/main.cpp
+	)
+
+	target_link_libraries(engine-sim-app
+		engine-sim-app-lib
+	)
+endif (BUILD_APP)
 
 # GTEST
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ option(DTV "Enable video output" OFF)
 option(PIRANHA_ENABLED "Enable scripting input" ON)
 option(DISCORD_ENABLED "Enable Discord Rich Presence" ON)
 option(BUILD_APP "Build Application" ON)
-option(BUILD_APP_AS_LIB "Build Application as a library" OFF)
+option(BUILD_APP_LIB "Build the application library. This library includes the visualization and simulation setup." ON)
 
 if (DTV)
     add_compile_definitions(ATG_ENGINE_SIM_VIDEO_CAPTURE)
@@ -207,7 +207,7 @@ if (DISCORD_ENABLED)
     )
 endif (DISCORD_ENABLED)
 
-if (BUILD_APP_AS_LIB OR BUILD_APP)
+if (BUILD_APP_LIB OR BUILD_APP)
 	add_library(engine-sim-app-lib STATIC
 		# Source files
 		src/engine_sim_application.cpp
@@ -306,7 +306,7 @@ if (BUILD_APP_AS_LIB OR BUILD_APP)
 		
 	add_subdirectory(dependencies/submodules/delta-studio)
 	add_subdirectory(dependencies/submodules/csv-io)
-endif (BUILD_APP_AS_LIB OR BUILD_APP)
+endif (BUILD_APP_LIB OR BUILD_APP)
 
 if (BUILD_APP)
 	add_executable(engine-sim-app WIN32


### PR DESCRIPTION
This PR splits up the executable into a static lib (engine-sim-app-lib) and fixes unused dependencies being added and compiled.

It also adds two more options to CMake: BUILD_APP and BUILD_APP_LIB.
- BUILD_APP builds the executable and the application library.
- BUILD_APP_LIB builds just the application library, in case you want to use just the library (like I do in my game)