### PR TITLE
Feat | engine switching helper

### DIFF
--- a/config-loader/CMakeLists.txt
+++ b/config-loader/CMakeLists.txt
@@ -1,0 +1,67 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(Config_Loader_for_Engine_Sim VERSION 0.1 LANGUAGES CXX)
+
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Widgets)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets)
+
+set(PROJECT_SOURCES
+        main.cpp
+        mainwindow.cpp
+        selectingdialog.cpp
+        mainwindow.h
+        selectingdialog.h
+        mainwindow.ui
+        selectingdialog.ui
+        resources/resources.qrc
+)
+
+if(${QT_VERSION_MAJOR} GREATER_EQUAL 6)
+    qt_add_executable(Config_Loader_for_Engine_Sim
+        MANUAL_FINALIZATION
+        ${PROJECT_SOURCES}
+    )
+# Define target properties for Android with Qt 6 as:
+#    set_property(TARGET Config_Loader_for_Engine_Sim APPEND PROPERTY QT_ANDROID_PACKAGE_SOURCE_DIR
+#                 ${CMAKE_CURRENT_SOURCE_DIR}/android)
+# For more information, see https://doc.qt.io/qt-6/qt-add-executable.html#target-creation
+else()
+    if(ANDROID)
+        add_library(Config_Loader_for_Engine_Sim SHARED
+            ${PROJECT_SOURCES}
+        )
+# Define properties for Android with Qt 5 after find_package() calls as:
+#    set(ANDROID_PACKAGE_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/android")
+    else()
+        add_executable(Config_Loader_for_Engine_Sim
+            ${PROJECT_SOURCES}
+        )
+    endif()
+endif()
+
+target_link_libraries(Config_Loader_for_Engine_Sim PRIVATE Qt${QT_VERSION_MAJOR}::Widgets)
+
+set_target_properties(Config_Loader_for_Engine_Sim PROPERTIES
+    MACOSX_BUNDLE_GUI_IDENTIFIER my.example.com
+    MACOSX_BUNDLE_BUNDLE_VERSION ${PROJECT_VERSION}
+    MACOSX_BUNDLE_SHORT_VERSION_STRING ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
+    MACOSX_BUNDLE TRUE
+    WIN32_EXECUTABLE TRUE
+)
+
+install(TARGETS Config_Loader_for_Engine_Sim
+    BUNDLE DESTINATION .
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+if(QT_VERSION_MAJOR EQUAL 6)
+    qt_finalize_executable(Config_Loader_for_Engine_Sim)
+endif()

--- a/config-loader/main.cpp
+++ b/config-loader/main.cpp
@@ -1,0 +1,26 @@
+/******************************************************************************
+ * A config loader with GUI.\
+ *   Users select an engine and theme,\
+ *   then "main.mr" will be automatically generated.
+ * @File: main.cpp
+ * @Author: Gol3vka<gol3vka@163.com>
+ * @Version: 2.0.0
+ * @What's new:
+ *   1) Modifying theme is available.\
+ *   2) Add a dialog for engine files where the program can not decide\
+ *      which is the engine node.
+ * @Created date: 2022/10/21
+ * @Last modified date: 2022/10/25
+ *****************************************************************************/
+
+#include <QApplication>
+
+#include "mainwindow.h"
+
+int main(int argc, char *argv[])
+{
+  QApplication a(argc, argv);
+  MainWindow w;
+  w.show();
+  return a.exec();
+}

--- a/config-loader/mainwindow.cpp
+++ b/config-loader/mainwindow.cpp
@@ -1,0 +1,390 @@
+/******************************************************************************
+ * A config loader with GUI.\
+ *   Users select an engine and theme,\
+ *   then "main.mr" will be automatically generated.
+ * @File: mainwindow.cpp
+ * @Brief: Mainwindow.
+ * @Author: Gol3vka<gol3vka@163.com>
+ * @Version: 2.0.0
+ * @What's new:
+ *   1) Modifying theme is available.\
+ *   2) Add a dialog for engine files where the program can not decide\
+ *      which is the engine node.
+ * @Created date: 2022/10/21
+ * @Last modified date: 2022/10/25
+ *****************************************************************************/
+
+// TODO: read old "main.mr" as default config,\
+//  so users dont need to modify evething.
+// TODO: add options of modifying units
+// TODO: provide preview of themes
+// TODO: more beautiful(icon, theme(synchronizing with engine sim), layout...)
+// ...
+
+#include "mainwindow.h"
+
+#include <QDebug>
+#include <QDir>
+#include <QFile>
+#include <QFileSystemModel>
+#include <QMessageBox>
+#include <QString>
+#include <QStringList>
+#include <QTextStream>
+
+#include "./ui_mainwindow.h"
+#include "selectingdialog.h"
+
+MainWindow::MainWindow(QWidget *parent)
+    : QMainWindow(parent), ui(new Ui::MainWindow)
+{
+  ui->setupUi(this);
+
+  /* set path of folders and "main.mr" */
+  // assets_folder_path = "C:/Program Files/Engine Sim/assets/";
+  assets_folder_path = "../assets/";
+  engines_folder_path = assets_folder_path + "engines/";
+  themes_folder_path = assets_folder_path + "themes/";
+  main_file_path = assets_folder_path + "main.mr";
+
+  /* check path */
+  if (!QDir(assets_folder_path).exists())
+  {
+    QMessageBox::critical(NULL, "ERROR", "Can not find folder \"assets\".",
+                          QMessageBox::Close);
+    exit(EXIT_FAILURE);
+  }
+  if (!QDir(engines_folder_path).exists())
+  {
+    QMessageBox::critical(NULL, "ERROR",
+                          "Can not find folder \"assets/engines\".",
+                          QMessageBox::Close);
+    exit(EXIT_FAILURE);
+  }
+  if (!QDir(themes_folder_path).exists())
+  {
+    QMessageBox::critical(NULL, "ERROR",
+                          "Can not find folder \"assets/themes\".",
+                          QMessageBox::Close);
+    exit(EXIT_FAILURE);
+  }
+
+  /****************************************************************************
+   *
+   * TODO: read old "mian.mr", store paths and set_commends,
+   *   provide default values.
+   *
+   ***************************************************************************/
+
+  /* set file filter */
+  filter.clear();
+  filter.append("*.mr");
+  /* create file system model */
+  file_model = new QFileSystemModel();
+  /* root path and filter */
+  file_model->setRootPath(assets_folder_path);
+  file_model->setNameFilters(filter);
+  file_model->setNameFilterDisables(false);
+  file_model->setReadOnly(false);
+
+  /* tree view of engine files */
+  engine_files_tree();
+  theme_files_tree();
+
+  /* default theme */
+  theme_file_name = "default.mr";
+  theme_file_path = themes_folder_path + "default.mr";
+  ui->theme_file_name_browser->setText("default");
+}
+
+MainWindow::~MainWindow()
+{
+  delete file_model;
+  delete ui;
+}
+
+/* display engine files in tree view */
+void MainWindow::engine_files_tree()
+{
+  /* bind file system model to tree view */
+  ui->engine_files_tree_view->setAnimated(true);
+  ui->engine_files_tree_view->setModel(file_model);
+  ui->engine_files_tree_view->setRootIndex(
+      file_model->index(engines_folder_path));
+
+  /* hide headers and columns */
+  ui->engine_files_tree_view->header()->hide();
+  for (int i = 1; i < 4; ++i) ui->engine_files_tree_view->hideColumn(i);
+}
+
+/******************************************************************************
+ *
+ * TODO: need a function "void read_main_file()".
+ *   store and set default values.
+ *
+ *****************************************************************************/
+
+/* display theme files in tree view */
+void MainWindow::theme_files_tree()
+{
+  /* bind file system model to tree view */
+  ui->theme_files_tree_view->setAnimated(true);
+  ui->theme_files_tree_view->setModel(file_model);
+  ui->theme_files_tree_view->setRootIndex(
+      file_model->index(themes_folder_path));
+
+  /* hide headers and columns */
+  ui->theme_files_tree_view->header()->hide();
+  for (int i = 1; i < 4; ++i) ui->theme_files_tree_view->hideColumn(i);
+}
+
+/* read engine file to get public nodes */
+QString MainWindow::read_engine_file(QFile &file)
+{
+  /* open and read the file line-by-line */
+  QStringList pub_nodes;
+  QByteArray line;
+  bool main_exists = false;
+  pub_nodes.clear();
+  line.clear();
+  if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
+    QMessageBox::critical(
+        NULL, "ERROR",
+        "Engine file \"" + engine_file_name + "\" is not accessible.",
+        QMessageBox::Ok);
+  else
+  {
+    while (!file.atEnd())
+    {
+      line = file.readLine();
+      /* search for public nodes */
+      /* break if "main" exists */
+      if (line.startsWith("public node main"))
+      {
+        main_exists = true;
+        break;
+      }
+      /* store the name of public node */
+      if (line.startsWith("public node")) pub_nodes.append(line.split(' ')[2]);
+    }
+    file.close();
+  }
+
+  QString set_engine_command;
+  if (main_exists)
+    set_engine_command = "main()";
+  else if (pub_nodes.size() < 1)
+    QMessageBox::critical(NULL, "ERROR", "Invalid engine file.",
+                          QMessageBox::Ok);
+  else if (pub_nodes.size() == 1)
+    set_engine_command = "set_engine(" + pub_nodes[0] + "())";
+  else
+  {
+    /* selecting dialog */
+    SelectingDialog *dialog = new SelectingDialog;
+    dialog->file_path = engine_file_path;
+    dialog->set_item(pub_nodes);
+    int dialog_ret = dialog->exec();
+    if (dialog_ret == QDialog::Accepted)
+    {
+      if (dialog->engine_idx != 0)
+        set_engine_command =
+            "set_engine(" + pub_nodes[dialog->engine_idx - 1] + "())";
+      if (dialog->transmission_idx != 0)
+        set_engine_command += "\nset_transmission(" +
+                              pub_nodes[dialog->transmission_idx - 1] + "())";
+      if (dialog->vehicle_idx != 0)
+        set_engine_command +=
+            "\nset_vehicle(" + pub_nodes[dialog->vehicle_idx - 1] + "())";
+    }
+    else if (dialog_ret == QDialog::Rejected)
+      set_engine_command.clear();
+    delete dialog;
+  }
+
+  return set_engine_command;
+}
+
+/* read theme file to get public nodes */
+QString MainWindow::read_theme_file(QFile &file)
+{
+  /* open and read the file line-by-line */
+  QString set_theme_command;
+  QStringList pub_nodes;
+  QByteArray line;
+  pub_nodes.clear();
+  line.clear();
+  if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
+    QMessageBox::critical(
+        NULL, "ERROR",
+        "Theme file \"" + theme_file_name + "\" is not accessible.",
+        QMessageBox::Ok);
+  else
+  {
+    while (!file.atEnd())
+    {
+      line = file.readLine();
+      /* search for public nodes */
+      if (line.startsWith("public node"))
+      {
+        set_theme_command = line.split(' ')[2] + '(';
+        break;
+      }
+    }
+    file.close();
+  }
+
+  return set_theme_command;
+}
+
+/* generate content of "main.mr" */
+QStringList MainWindow::generate_main_content(const QString &set_theme_command,
+                                              const QString &set_engine_command)
+{
+  QDir assets_dir(assets_folder_path);
+  QStringList content;
+  content.clear();
+  content.append("import \"engine_sim.mr\"");
+  /* import theme */
+  content.append("\n/********** import theme **********/");
+  content.append("import \"" + assets_dir.relativeFilePath(theme_file_path) +
+                 '\"');
+  /* import engine */
+  content.append("\n/********** import engine **********/");
+  content.append("import \"" + assets_dir.relativeFilePath(engine_file_path) +
+                 '\"');
+  /* set theme & units */
+  content.append("\n/********** set theme & units **********/");
+  content.append("unit_names units()");
+  content.append(set_theme_command);
+
+  /****************************************************************************
+   *
+   * TODO: modify units here, use parameters or add member vars.
+   *
+   ***************************************************************************/
+
+  content.append(")");
+  /* set engine */
+  content.append("\n/********** set engine **********/");
+  content.append(set_engine_command);
+
+  return content;
+}
+
+/* write into "main.mr" file */
+void MainWindow::write_main_file(QFile &file, const QStringList &content)
+{
+  if (!file.open(QIODevice::WriteOnly | QIODevice::Text))
+    QMessageBox::critical(NULL, "ERROR", "File \"main.mr\" is not accessible.",
+                          QMessageBox::Ok);
+  else
+  {
+    QTextStream stream(&file);
+    for (int i = 0; i < content.size(); ++i) stream << content[i] << "\n";
+    file.close();
+  }
+}
+
+/* get selected item from engine files tree */
+void MainWindow::on_engine_files_tree_view_clicked(const QModelIndex &index)
+{
+  /* get the type of selected item */
+  QString type = file_model->type(index);
+  if (type == "File Folder") return;
+
+  /* display the name of selected file */
+  engine_file_name = file_model->fileName(index);
+  engine_file_path = file_model->filePath(index);
+  ui->engine_file_name_browser->setText(
+      engine_file_name.left(engine_file_name.size() - 3));
+}
+
+/* get selected item from theme files tree */
+void MainWindow::on_theme_files_tree_view_clicked(const QModelIndex &index)
+{
+  /* get the type of selected item */
+  QString type = file_model->type(index);
+  if (type == "File Folder") return;
+
+  /* display the name of selected file */
+  theme_file_name = file_model->fileName(index);
+  theme_file_path = file_model->filePath(index);
+  ui->theme_file_name_browser->setText(
+      theme_file_name.left(theme_file_name.size() - 3));
+}
+
+/* apply and write into "main.mr" */
+void MainWindow::on_apply_button_clicked()
+{
+  /* ensure an engine file is selected */
+  if (engine_file_name.isEmpty())
+  {
+    QMessageBox::critical(NULL, "ERROR", "Please select an engine.",
+                          QMessageBox::Ok);
+    return;
+  }
+
+  /* get the selected engine file */
+  QFile engine_file(engine_file_path);
+  if (!engine_file.exists())
+  {
+    QMessageBox::critical(
+        NULL, "ERROR", "Can not find engine file \"" + engine_file_name + "\".",
+        QMessageBox::Ok);
+    return;
+  }
+  /* get the selected theme file */
+  QFile theme_file(theme_file_path);
+  if (!theme_file.exists())
+  {
+    QMessageBox::critical(
+        NULL, "ERROR", "Can not find theme file \"" + theme_file_name + "\".",
+        QMessageBox::Ok);
+    return;
+  }
+
+  /* read the engine file */
+  QString set_engine_command = read_engine_file(engine_file);
+  /* user selects nothing or cancels */
+  if (set_engine_command.isEmpty())
+  {
+    QMessageBox::information(NULL, "INFO", "Nothing is written in \"main.mr\".",
+                             QMessageBox::Ok);
+    return;
+  }
+  /* read the theme file */
+  QString set_theme_command = read_theme_file(theme_file);
+
+  /* generate content of "main.mr" */
+  QStringList main_content =
+      generate_main_content(set_theme_command, set_engine_command);
+
+  /* remove old backup file */
+  QFile main_file_backup(main_file_path + ".backup");
+  if (!main_file_backup.remove())
+    QMessageBox::critical(NULL, "ERROR", main_file_backup.errorString(),
+                          QMessageBox::Ok);
+  /* back up "main.mr" to "main.mr.backup" before modifying */
+  QFile main_file(main_file_path);
+  if (!main_file.copy(main_file.fileName() + ".backup"))
+    QMessageBox::critical(NULL, "ERROR", main_file.errorString(),
+                          QMessageBox::Ok);
+
+  /* write into the main file */
+  write_main_file(main_file, main_content);
+
+  /* notify */
+  QMessageBox::information(
+      NULL, "INFO",
+      "Successful!\nOld configuration is backed up to \"main.mr.backup\".",
+      QMessageBox::Ok);
+}
+
+/* quit */
+void MainWindow::on_quit_button_clicked()
+{
+  delete file_model;
+  delete ui;
+  exit(EXIT_SUCCESS);
+}

--- a/config-loader/mainwindow.h
+++ b/config-loader/mainwindow.h
@@ -1,0 +1,84 @@
+/******************************************************************************
+ * A config loader with GUI.\
+ *   Users select an engine and theme,\
+ *   then "main.mr" will be automatically generated.
+ * @File: mainwindow.h
+ * @Brief: Mainwindow.
+ * @Author: Gol3vka<gol3vka@163.com>
+ * @Version: 2.0.0
+ * @What's new:
+ *   1) Modifying theme is available.\
+ *   2) Add a dialog for engine files where the program can not decide\
+ *      which is the engine node.
+ * @Created date: 2022/10/21
+ * @Last modified date: 2022/10/25
+ *****************************************************************************/
+
+#ifndef MAINWINDOW_H
+#define MAINWINDOW_H
+
+#include <QFile>
+#include <QFileSystemModel>
+#include <QMainWindow>
+#include <QString>
+#include <QStringList>
+
+QT_BEGIN_NAMESPACE
+namespace Ui
+{
+class MainWindow;
+}
+QT_END_NAMESPACE
+
+class MainWindow : public QMainWindow
+{
+  Q_OBJECT
+
+ public:
+  MainWindow(QWidget *parent = nullptr);
+  ~MainWindow();
+
+ private slots:
+  /* get selected item from engine files tree */
+  void on_engine_files_tree_view_clicked(const QModelIndex &index);
+  /* get selected item from theme files tree */
+  void on_theme_files_tree_view_clicked(const QModelIndex &index);
+
+  /* apply and write into "main.mr" */
+  void on_apply_button_clicked();
+  /* quit */
+  void on_quit_button_clicked();
+
+ private:
+  /* display engine files in tree view */
+  void engine_files_tree();
+  /* display theme files in tree view */
+  void theme_files_tree();
+
+  /* read engine file to get public nodes */
+  QString read_engine_file(QFile &file);
+  /* read theme file to get public nodes */
+  QString read_theme_file(QFile &file);
+
+  /* generate content of "main.mr" */
+  QStringList generate_main_content(const QString &set_theme_command,
+                                    const QString &set_engine_command);
+  /* write into "main.mr" file */
+  void write_main_file(QFile &file, const QStringList &content);
+
+  Ui::MainWindow *ui;
+
+  QFileSystemModel *file_model;
+  QStringList filter;
+
+  QString assets_folder_path;
+  QString engines_folder_path;
+  QString themes_folder_path;
+  QString main_file_path;
+
+  QString engine_file_name;
+  QString engine_file_path;
+  QString theme_file_name;
+  QString theme_file_path;
+};
+#endif  // MAINWINDOW_H

--- a/config-loader/mainwindow.ui
+++ b/config-loader/mainwindow.ui
@@ -1,0 +1,252 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>MainWindow</class>
+ <widget class="QMainWindow" name="MainWindow">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>800</width>
+    <height>600</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>MainWindow</string>
+  </property>
+  <widget class="QWidget" name="centralwidget">
+   <widget class="QTreeView" name="engine_files_tree_view">
+    <property name="geometry">
+     <rect>
+      <x>30</x>
+      <y>50</y>
+      <width>331</width>
+      <height>231</height>
+     </rect>
+    </property>
+    <property name="frameShape">
+     <enum>QFrame::Box</enum>
+    </property>
+   </widget>
+   <widget class="QTextBrowser" name="engine_file_name_browser">
+    <property name="geometry">
+     <rect>
+      <x>440</x>
+      <y>340</y>
+      <width>331</width>
+      <height>31</height>
+     </rect>
+    </property>
+    <property name="frameShape">
+     <enum>QFrame::Box</enum>
+    </property>
+   </widget>
+   <widget class="QPushButton" name="apply_button">
+    <property name="geometry">
+     <rect>
+      <x>480</x>
+      <y>540</y>
+      <width>92</width>
+      <height>29</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Apply</string>
+    </property>
+   </widget>
+   <widget class="QPushButton" name="quit_button">
+    <property name="geometry">
+     <rect>
+      <x>640</x>
+      <y>540</y>
+      <width>92</width>
+      <height>29</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Quit</string>
+    </property>
+   </widget>
+   <widget class="QLabel" name="engine_lable">
+    <property name="geometry">
+     <rect>
+      <x>30</x>
+      <y>10</y>
+      <width>301</width>
+      <height>31</height>
+     </rect>
+    </property>
+    <property name="font">
+     <font>
+      <pointsize>12</pointsize>
+     </font>
+    </property>
+    <property name="frameShape">
+     <enum>QFrame::NoFrame</enum>
+    </property>
+    <property name="text">
+     <string>| Engine Files</string>
+    </property>
+    <property name="textFormat">
+     <enum>Qt::PlainText</enum>
+    </property>
+   </widget>
+   <widget class="QTreeView" name="theme_files_tree_view">
+    <property name="geometry">
+     <rect>
+      <x>30</x>
+      <y>340</y>
+      <width>331</width>
+      <height>231</height>
+     </rect>
+    </property>
+    <property name="frameShape">
+     <enum>QFrame::Box</enum>
+    </property>
+   </widget>
+   <widget class="QLabel" name="theme_lable">
+    <property name="geometry">
+     <rect>
+      <x>30</x>
+      <y>300</y>
+      <width>301</width>
+      <height>31</height>
+     </rect>
+    </property>
+    <property name="font">
+     <font>
+      <pointsize>12</pointsize>
+     </font>
+    </property>
+    <property name="frameShape">
+     <enum>QFrame::NoFrame</enum>
+    </property>
+    <property name="text">
+     <string>| Theme Files</string>
+    </property>
+    <property name="textFormat">
+     <enum>Qt::PlainText</enum>
+    </property>
+   </widget>
+   <widget class="QTextBrowser" name="theme_file_name_browser">
+    <property name="geometry">
+     <rect>
+      <x>440</x>
+      <y>430</y>
+      <width>331</width>
+      <height>31</height>
+     </rect>
+    </property>
+    <property name="frameShape">
+     <enum>QFrame::Box</enum>
+    </property>
+   </widget>
+   <widget class="QLabel" name="unit_lable">
+    <property name="geometry">
+     <rect>
+      <x>440</x>
+      <y>10</y>
+      <width>301</width>
+      <height>31</height>
+     </rect>
+    </property>
+    <property name="font">
+     <font>
+      <pointsize>12</pointsize>
+     </font>
+    </property>
+    <property name="frameShape">
+     <enum>QFrame::NoFrame</enum>
+    </property>
+    <property name="text">
+     <string>| Units</string>
+    </property>
+    <property name="textFormat">
+     <enum>Qt::PlainText</enum>
+    </property>
+   </widget>
+   <widget class="QLabel" name="selected_engine_lable">
+    <property name="geometry">
+     <rect>
+      <x>440</x>
+      <y>300</y>
+      <width>301</width>
+      <height>31</height>
+     </rect>
+    </property>
+    <property name="font">
+     <font>
+      <pointsize>12</pointsize>
+     </font>
+    </property>
+    <property name="frameShape">
+     <enum>QFrame::NoFrame</enum>
+    </property>
+    <property name="text">
+     <string>| Selected Engine File</string>
+    </property>
+    <property name="textFormat">
+     <enum>Qt::PlainText</enum>
+    </property>
+   </widget>
+   <widget class="QLabel" name="selected_theme_lable">
+    <property name="geometry">
+     <rect>
+      <x>440</x>
+      <y>390</y>
+      <width>301</width>
+      <height>31</height>
+     </rect>
+    </property>
+    <property name="font">
+     <font>
+      <pointsize>12</pointsize>
+     </font>
+    </property>
+    <property name="frameShape">
+     <enum>QFrame::NoFrame</enum>
+    </property>
+    <property name="text">
+     <string>| Selected Theme File</string>
+    </property>
+    <property name="textFormat">
+     <enum>Qt::PlainText</enum>
+    </property>
+   </widget>
+   <widget class="QLabel" name="temp">
+    <property name="geometry">
+     <rect>
+      <x>440</x>
+      <y>50</y>
+      <width>331</width>
+      <height>231</height>
+     </rect>
+    </property>
+    <property name="font">
+     <font>
+      <pointsize>12</pointsize>
+     </font>
+    </property>
+    <property name="frameShape">
+     <enum>QFrame::Box</enum>
+    </property>
+    <property name="frameShadow">
+     <enum>QFrame::Sunken</enum>
+    </property>
+    <property name="text">
+     <string>**********************
+* To Be Developed... *
+**********************</string>
+    </property>
+    <property name="textFormat">
+     <enum>Qt::PlainText</enum>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+   </widget>
+  </widget>
+  <widget class="QStatusBar" name="statusbar"/>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/config-loader/resources/resources.qrc
+++ b/config-loader/resources/resources.qrc
@@ -1,0 +1,3 @@
+<RCC>
+    <qresource prefix="/icons"/>
+</RCC>

--- a/config-loader/selectingdialog.cpp
+++ b/config-loader/selectingdialog.cpp
@@ -1,0 +1,66 @@
+/******************************************************************************
+ * A config loader with GUI.\
+ *   Users select an engine and theme,\
+ *   then "main.mr" will be automatically generated.
+ * @File: selectingdialog.cpp
+ * @Brife: A dialog for users to select engine, transmission and vehicle nodes.
+ * @Author: Gol3vka<gol3vka@163.com>
+ * @Version: 2.0.0
+ * @What's new:
+ *   1) Modifying theme is available.\
+ *   2) Add a dialog for engine files where the program can not decide\
+ *      which is the engine node.
+ * @Created date: 2022/10/21
+ * @Last modified date: 2022/10/25
+ *****************************************************************************/
+
+#include "selectingdialog.h"
+
+#include <QDesktopServices>
+#include <QDir>
+#include <QUrl>
+
+#include "ui_selectingdialog.h"
+
+SelectingDialog::SelectingDialog(QWidget *parent)
+    : QDialog(parent), ui(new Ui::SelectingDialog)
+{
+  ui->setupUi(this);
+  engine_idx = 0;
+  transmission_idx = 0;
+  vehicle_idx = 0;
+}
+
+SelectingDialog::~SelectingDialog() { delete ui; }
+
+/* set item for combo boxes */
+void SelectingDialog::set_item(const QStringList &pub_nodes)
+{
+  ui->engine_selector->addItem("--None--");
+  ui->transmission_selector->addItem("--None--");
+  ui->vehicle_selector->addItem("--None--");
+
+  ui->engine_selector->addItems(pub_nodes);
+  ui->transmission_selector->addItems(pub_nodes);
+  ui->vehicle_selector->addItems(pub_nodes);
+}
+
+/* get user selection */
+void SelectingDialog::on_engine_selector_activated(int index)
+{
+  engine_idx = index;
+}
+void SelectingDialog::on_transmission_selector_activated(int index)
+{
+  transmission_idx = index;
+}
+void SelectingDialog::on_vehicle_selector_activated(int index)
+{
+  vehicle_idx = index;
+}
+
+/* open the file */
+void SelectingDialog::on_open_button_clicked()
+{
+  QDesktopServices::openUrl(QUrl(QDir::fromNativeSeparators(file_path)));
+}

--- a/config-loader/selectingdialog.h
+++ b/config-loader/selectingdialog.h
@@ -1,0 +1,59 @@
+/******************************************************************************
+ * A config loader with GUI.\
+ *   Users select an engine and theme,\
+ *   then "main.mr" will be automatically generated.
+ * @File: selectingdialog.h
+ * @Brife: A dialog for users to select engine, transmission and vehicle nodes.
+ * @Author: Gol3vka<gol3vka@163.com>
+ * @Version: 2.0.0
+ * @What's new:
+ *   1) Modifying theme is available.\
+ *   2) Add a dialog for engine files where the program can not decide\
+ *      which is the engine node.
+ * @Created date: 2022/10/21
+ * @Last modified date: 2022/10/25
+ *****************************************************************************/
+
+#ifndef SELECTINGDIALOG_H
+#define SELECTINGDIALOG_H
+
+#include <QDialog>
+
+namespace Ui
+{
+class SelectingDialog;
+}
+
+class SelectingDialog : public QDialog
+{
+  Q_OBJECT
+
+ public:
+  explicit SelectingDialog(QWidget *parent = nullptr);
+  ~SelectingDialog();
+
+  /* set item for combo boxes */
+  void set_item(const QStringList &pub_nodes);
+
+  /* user selection */
+  int engine_idx;
+  int transmission_idx;
+  int vehicle_idx;
+
+  /* file path */
+  QString file_path;
+
+ private slots:
+  /* get user selection */
+  void on_engine_selector_activated(int index);
+  void on_transmission_selector_activated(int index);
+  void on_vehicle_selector_activated(int index);
+
+  /* open the file */
+  void on_open_button_clicked();
+
+ private:
+  Ui::SelectingDialog *ui;
+};
+
+#endif  // SELECTINGDIALOG_H

--- a/config-loader/selectingdialog.ui
+++ b/config-loader/selectingdialog.ui
@@ -1,0 +1,198 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>SelectingDialog</class>
+ <widget class="QDialog" name="SelectingDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <widget class="QDialogButtonBox" name="buttonBox">
+   <property name="geometry">
+    <rect>
+     <x>200</x>
+     <y>240</y>
+     <width>171</width>
+     <height>31</height>
+    </rect>
+   </property>
+   <property name="orientation">
+    <enum>Qt::Horizontal</enum>
+   </property>
+   <property name="standardButtons">
+    <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+   </property>
+  </widget>
+  <widget class="QComboBox" name="engine_selector">
+   <property name="geometry">
+    <rect>
+     <x>170</x>
+     <y>50</y>
+     <width>201</width>
+     <height>28</height>
+    </rect>
+   </property>
+   <property name="font">
+    <font>
+     <pointsize>10</pointsize>
+    </font>
+   </property>
+  </widget>
+  <widget class="QComboBox" name="transmission_selector">
+   <property name="geometry">
+    <rect>
+     <x>170</x>
+     <y>110</y>
+     <width>201</width>
+     <height>28</height>
+    </rect>
+   </property>
+   <property name="font">
+    <font>
+     <pointsize>10</pointsize>
+    </font>
+   </property>
+  </widget>
+  <widget class="QComboBox" name="vehicle_selector">
+   <property name="geometry">
+    <rect>
+     <x>170</x>
+     <y>170</y>
+     <width>201</width>
+     <height>28</height>
+    </rect>
+   </property>
+   <property name="font">
+    <font>
+     <pointsize>10</pointsize>
+    </font>
+   </property>
+  </widget>
+  <widget class="QLabel" name="engine_label">
+   <property name="geometry">
+    <rect>
+     <x>30</x>
+     <y>50</y>
+     <width>121</width>
+     <height>28</height>
+    </rect>
+   </property>
+   <property name="font">
+    <font>
+     <pointsize>10</pointsize>
+     <underline>false</underline>
+     <strikeout>false</strikeout>
+     <kerning>true</kerning>
+    </font>
+   </property>
+   <property name="text">
+    <string>Engine :</string>
+   </property>
+   <property name="alignment">
+    <set>Qt::AlignCenter</set>
+   </property>
+  </widget>
+  <widget class="QLabel" name="transmission_label">
+   <property name="geometry">
+    <rect>
+     <x>30</x>
+     <y>110</y>
+     <width>121</width>
+     <height>28</height>
+    </rect>
+   </property>
+   <property name="font">
+    <font>
+     <pointsize>10</pointsize>
+    </font>
+   </property>
+   <property name="text">
+    <string>Transmission :</string>
+   </property>
+   <property name="alignment">
+    <set>Qt::AlignCenter</set>
+   </property>
+  </widget>
+  <widget class="QLabel" name="vehicle_label">
+   <property name="geometry">
+    <rect>
+     <x>30</x>
+     <y>170</y>
+     <width>121</width>
+     <height>28</height>
+    </rect>
+   </property>
+   <property name="font">
+    <font>
+     <pointsize>10</pointsize>
+    </font>
+   </property>
+   <property name="text">
+    <string>Vehicle :</string>
+   </property>
+   <property name="alignment">
+    <set>Qt::AlignCenter</set>
+   </property>
+  </widget>
+  <widget class="QPushButton" name="open_button">
+   <property name="geometry">
+    <rect>
+     <x>30</x>
+     <y>245</y>
+     <width>81</width>
+     <height>25</height>
+    </rect>
+   </property>
+   <property name="sizePolicy">
+    <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+     <horstretch>0</horstretch>
+     <verstretch>0</verstretch>
+    </sizepolicy>
+   </property>
+   <property name="text">
+    <string>Open file</string>
+   </property>
+  </widget>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>SelectingDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>SelectingDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>


### PR DESCRIPTION
Hello!

The folder "config-loader" is what I added. It helps change engines, themes and units, more easily. Because I find it troublesome to modify the "main.mr" manually.

**It's written in Qt.**

This is my repo: [Config Loader for Engine Sim](https://github.com/Golevka2001/Config-Loader-for-Engine-Sim)

![main_window_1](https://user-images.githubusercontent.com/101185502/197799062-f5fb3380-247c-4c85-8587-47fac2f198ca.png)
