### PR TITLE
Preparation for macOS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ compile_commands.json
 
 # Blender temporary files
 *.blend1
+
+# MacOS directory Metadata
+*.DS_Store
+   

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "dependencies/submodules/delta-studio"]
 	path = dependencies/submodules/delta-studio
-	url = https://github.com/ange-yaghi/delta-studio
+	url = git@github.com:ange-yaghi/delta-studio.git
 [submodule "dependencies/submodules/simple-2d-constraint-solver"]
 	path = dependencies/submodules/simple-2d-constraint-solver
 	url = https://github.com/ange-yaghi/simple-2d-constraint-solver
@@ -12,4 +12,4 @@
 	url = https://github.com/ange-yaghi/csv-io
 [submodule "dependencies/submodules/piranha"]
 	path = dependencies/submodules/piranha
-	url = https://github.com/ange-yaghi/piranha.git
+	url = git@github.com:ange-yaghi/piranha.git


### PR DESCRIPTION
I'm aiming to see about the possibility of having the project running on macOS. 

These changes are pretty basic for now and are just a preparation.

- Added `.DS_Store` to `.gitignore`: 
This is a hidden metadata file for directories on Mac that is not relevant to the project.

- Used SSH protocol for fetching submodules instead of HTTPS:
This change was actually necessary for all contributors as fetching submodules with large volumes can be troublesome, especially for those with a poor network connection. 
Previously, cloning the modules frequently resulted in errors like "`unexpected disconnect while reading sideband packet.`" 
Switching the URL of modules exceeding **100MB** from HTTPS to SSH resolved this issue.
